### PR TITLE
'make clean' deletes *~ files and package/ directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,3 +30,4 @@ archive: changelog
 	xz -f package/$(PREFIX).tar
 
 clean:
+	@rm -rf *~ package


### PR DESCRIPTION
It should fix Jenkins builds.
