### PR TITLE
get version numbering right when starting a new numbering scheme

### DIFF
--- a/git2log
+++ b/git2log
@@ -481,8 +481,8 @@ sub choose_tags
     # If a commit is tagged  "FOO-X.Y" *and* "FOO-X.Y.0" assume the user
     # wants to start a new sub-numbering scheme.
     #
-    # Use "X.Y" as version but remember to go to "X.Y.1" when we need to
-    # increment the version.
+    # Use "X.Y" as version but remember to go to "X.Y.1" instead of
+    # "X.{Y+1}" when we need to increment the version.
     #
     my $version = $t[0]{version};
     if($version =~ s/\.0$//) {

--- a/git2log
+++ b/git2log
@@ -475,6 +475,23 @@ sub choose_tags
     @t = sort tag_sort @t;
 
     $branch = $t[0]{branch};
+
+    # Here's some magic:
+    #
+    # If a commit is tagged  "FOO-X.Y" *and* "FOO-X.Y.0" assume the user
+    # wants to start a new sub-numbering scheme.
+    #
+    # Use "X.Y" as version but remember to go to "X.Y.1" when we need to
+    # increment the version.
+    #
+    my $version = $t[0]{version};
+    if($version =~ s/\.0$//) {
+      if(grep { $_->{branch} eq $branch && $_->{version} eq $version } @t) {
+        $t[0]{new_start} = 1;
+        $t[0]{version} = $version;
+      }
+    }
+
     $x->{tags} = [ $t[0] ];
 
     # printf "X %s\n", tags_to_str($x->{tags});
@@ -489,6 +506,8 @@ sub choose_tags
 #
 # Basically, use branch + version from most recent tag and increment version.
 #
+# If the 'new_start' attribute to tag is set, start a new sub-numbering scheme.
+#
 sub add_head_tag
 {
   return if @{$config->{log}} < 2;
@@ -498,6 +517,9 @@ sub add_head_tag
 
   # the first tagged commit if HEAD isn't tagged
   my $tag = { %{$config->{log}[1]{tags}[0]} };
+
+  # append '.0' to version
+  $tag->{version} .= '.0' if $tag->{new_start};
 
   # increment version
   $tag->{version} =~ s/(\d+)$/$1 + 1/e;


### PR DESCRIPTION
## Problem

It's quite tricky to start a new branch with a new sub-numbering scheme.

For example branching off at `X.Y` to start with `FOO-X.Y.1`. It's hard to automatically guess that
 `FOO-X.Y.1` directly follows  `X.Y` **and** that the predecessor of  `FOO-X.Y.1` is not  `FOO-X.Y.0`.

## Solution

So here's the magic: tag the branching point as both `FOO-X.Y` **and** `FOO-X.Y.0`. `git2log` will now understand that  `FOO-X.Y.0` is just an alias to  `FOO-X.Y` and you simply want the next version to be `FOO-X.Y.1` and not `FOO-X.{Y+1}`.