### PR TITLE
do not supersede staging requests

### DIFF
--- a/make_package
+++ b/make_package
@@ -37,7 +37,14 @@ PACKAGE_PREFIX=$PACKAGE_NAME-$VERSION
 mkdir -p package
 rm -f package/*.tar.xz package/*.changes
 
+extra_files=VERSION
+
 git2log --changelog --format obs package/$PACKAGE_NAME.changes
+
+if [ -f changelog ] || grep -q ^changelog: Makefile ; then
+  git2log --changelog changelog
+  extra_files="$extra_files changelog"
+fi
 
 if [ ! -d .git ] ; then
   echo no git repo
@@ -49,5 +56,5 @@ git archive --prefix=$PACKAGE_PREFIX/ HEAD > package/$PACKAGE_PREFIX.tar
 tar -r -f package/$PACKAGE_PREFIX.tar \
   --mode=0664 --owner=root --group=root \
   --mtime="`git show -s --format=%ci`" \
-  --transform="s:^:$PACKAGE_PREFIX/:" VERSION
+  --transform="s:^:$PACKAGE_PREFIX/:" $extra_files
 xz -f package/$PACKAGE_PREFIX.tar

--- a/tobs
+++ b/tobs
@@ -787,11 +787,45 @@ sub do_sr
 
   print "Creating submit request to $config->{sr}\n";
 
+  # get list of existing requests, most recent first
+  my $requests;
+
+  if(open my $p, "osc -A https://$bs request list $s[0]/$s[1] |") {
+    while(<$p>) {
+      if(/^(\d+)\s+State:(\S+)/) {
+        unshift @$requests, { id => $1, state => $2 };
+        next;
+      }
+      if($requests && /^\s*Review by Project\s.*\:Staging\:/) {
+        $requests->[0]{staging} = 1;
+        next;
+      }
+    }
+    close $p;
+  }
+
+  # if the most recent request is a review in staging, don't replace it
+
+  my $answer = "y";
+  my $super_id;
+
+  if($requests) {
+    $super_id = $requests->[0]{id};
+    if($requests->[0]{state} eq "review" && $requests->[0]{staging}) {
+      $answer = "n";
+      print "Not superseding staging request \#$super_id\n";
+    }
+    else {
+      print "Superseding exsting request \#$super_id\n";
+    }
+  }
+
   if(!$opt_try) {
     my $sr_resp = $tmp->file();
     my $user = $config->{email};
+    my $s_opt = $super_id && $answer eq "y" ? "-s $super_id" : "";
     $user =~ s/\@.*$//;
-    system "echo y | osc -A https://$bs sr -m 'submitted by $user via jenkins' --yes --nodevelproject $bs_prefix$config->{prj} $s[1] $s[0] >$sr_resp 2>&1";
+    system "echo $answer | osc -A https://$bs sr -m 'submitted by $user via jenkins' $s_opt --nodevelproject $bs_prefix$config->{prj} $s[1] $s[0] >$sr_resp 2>&1";
     $err = $? >> 8;
 
     my $resp_msg;


### PR DESCRIPTION
## Task

Automatically superseding requests that are currently reviewed in Staging is not ideal.

## Solution

Get a list of requests for the target project and if the most recent request is in state 'review' and mentioning 'Staging' in the comment, then don't supersede it. In all other cases, the most recent request is superseded.

Before, **all** existing requests were replaced by the new one.

## Feedback

No, this does not help.