### PR TITLE
include full URL to submit request in log

### DIFF
--- a/git2log
+++ b/git2log
@@ -65,6 +65,8 @@ my $opt_keep_date = 1;			# don't join consecutive commit messages if they have d
 my $opt_default_email = 'opensuse-packaging@opensuse.org';	# default email to use in changelog
 my $opt_weblate = 'bsc#1149754';	# bugzilla ref to use for Weblate commits
 
+$opt_default_email = $ENV{GIT2LOG_DEFAULT_EMAIL} if $ENV{GIT2LOG_DEFAULT_EMAIL};
+
 GetOptions(
   'help'          => sub { usage 0 },
   'version'       => \$opt_version,

--- a/tobs
+++ b/tobs
@@ -766,6 +766,13 @@ sub do_sr
         $err = 0;
       }
     }
+    else {
+      if($resp_msg =~ /created request id (\d+)/) {
+        my $url = "$sr->{api}/request/show/$1";
+        $url =~ s#^api\.#https://build.#;
+        print "Submit request URL: $url\n";
+      }
+    }
 
     print $resp_msg;
   }


### PR DESCRIPTION
## Task

- Include the full submit request URL in log. To get something klickable.
- Accept fallback e-mail also via envirionment setting. This is easier to use in build scripts.