### PR TITLE
allow submitting the same sources under different package names

### DIFF
--- a/build_it
+++ b/build_it
@@ -40,6 +40,12 @@ while true ; do
     continue
   fi
 
+  if [ "$1" = "--no-tag" ] ; then
+    tag_opt="--no-tag"
+    shift
+    continue
+  fi
+
   break
 done
 
@@ -63,7 +69,7 @@ else
   $prepare
 fi
 
-tobs $target $spec_opt $obs_opt
+tobs $target $spec_opt $obs_opt $tag_opt
 
 if [ -z "$prepare" ] ; then
   make $clean_target

--- a/git2log
+++ b/git2log
@@ -868,7 +868,7 @@ sub format_log
   }
 
   # step 9
-  # - remove shortened lines (that match the beginning of other lines)
+  # - remove shortened lines (that [case-insensitive] match the beginning of other lines)
 
   for my $commit (@$commits) {
     next unless $commit->{formatted};
@@ -879,7 +879,7 @@ sub format_log
       $str =~ s/\s*…$//;	# github likes to shorten lines with ' …'
       my $str_len = length $str;
       for (@{$commit->{formatted}}) {
-        return 1 if $str_len < length($_) && $str eq substr($_, 0, $str_len);
+        return 1 if $str_len < length($_) && "\L$str" eq substr("\L$_", 0, $str_len);
       }
 
       return 0;

--- a/make_package
+++ b/make_package
@@ -19,6 +19,14 @@ while true ; do
     continue
   fi
 
+  if [ "$1" = "--set-name" ] ; then
+    PACKAGE_NAME="$2"
+    set_name=1
+    shift
+    shift
+    continue
+  fi
+
   break
 done
 
@@ -46,6 +54,11 @@ if [ -f changelog ] || grep -q ^changelog: Makefile ; then
   extra_files="$extra_files changelog"
 fi
 
+if [ "$set_name" = 1 ] ; then
+  echo "$PACKAGE_NAME" > PACKAGE_NAME
+  extra_files="$extra_files PACKAGE_NAME"
+fi
+
 if [ ! -d .git ] ; then
   echo no git repo
   exit 1
@@ -58,3 +71,7 @@ tar -r -f package/$PACKAGE_PREFIX.tar \
   --mtime="`git show -s --format=%ci`" \
   --transform="s:^:$PACKAGE_PREFIX/:" $extra_files
 xz -f package/$PACKAGE_PREFIX.tar
+
+if [ "$set_name" = 1 ] ; then
+  rm -f PACKAGE_NAME
+fi

--- a/tobs
+++ b/tobs
@@ -284,7 +284,11 @@ die "missing changes\n" if !defined $config->{changes};
 
 # copy OBS files
 if($opt_obs) {
-  system "cp $opt_obs/* $tmpdir_from/$config->{package}/"
+  system "cp $opt_obs/* $tmpdir_from/$config->{package}/";
+  # keep only one spec file
+  for my $s (glob "$tmpdir_from/$config->{package}/*spec") {
+    unlink $s if $s !~ /\/$config->{spec_name}.spec$/;
+  }
 }
 
 update_spec;


### PR DESCRIPTION
## Tasks

1. When checking for duplicate log lines, so case-insensitive matches.
2. Allow different package names for the same sources. Spec files must be explicitly provided for each package name.